### PR TITLE
Project name/ID explanation

### DIFF
--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -21,7 +21,7 @@ namespace Crayon
 			"",
 			"  -output            Output directory. Compiled output will go here.",
 			"",
-			"  -name              Project name.",
+			"  -name              Project name (project ID).",
 			"",
 			"  -platform          Platform to compile to.",
 			"     Platform choices:",


### PR DESCRIPTION
If -name is not given, the compiler errors saying the 'project ID' is incorrect. Clarify more in the usage note.