### PR TITLE
PHP ref hack successful!

### DIFF
--- a/Compiler/Translator/AbstractTranslator.cs
+++ b/Compiler/Translator/AbstractTranslator.cs
@@ -126,17 +126,21 @@ namespace Crayon.Translator
 			}
 		}
 
-		private void TranslateDefaultBinaryOp(List<string> output, BinaryOpChain binOp)
-		{
-			output.Add("(");
-			this.TranslateExpression(output, binOp.Left);
-			output.Add(" ");
-			output.Add(binOp.Op.Value);
-			output.Add(" ");
-			this.TranslateExpression(output, binOp.Right);
-			output.Add(")");
-		}
+        private void TranslateDefaultBinaryOp(List<string> output, BinaryOpChain binOp)
+        {
+            output.Add("(");
+            this.TranslateExpression(output, binOp.Left);
+            output.Add(" ");
+            this.TranslateBinaryOpSyntax(output, binOp.Op.Value);
+            output.Add(" ");
+            this.TranslateExpression(output, binOp.Right);
+            output.Add(")");
+        }
 
+        protected virtual void TranslateBinaryOpSyntax(List<string> output, string tokenValue)
+        {
+            output.Add(tokenValue);
+        }
 
 		private void TranslateSystemFunctionCall(List<string> output, SystemFunctionCall systemFunctionCall)
 		{

--- a/Compiler/Translator/PHP/PhpPlatform.cs
+++ b/Compiler/Translator/PHP/PhpPlatform.cs
@@ -99,9 +99,9 @@ namespace Crayon.Translator.Php
             }
             output.Add(");");
 
-            output.Add("$e = array(array());");
-            output.Add("$z = array(array(0));");
-            output.Add("$o = array(array(1));");
+            output.Add("$e = new Rf(array());");
+            output.Add("$z = new Rf(array(0));");
+            output.Add("$o = new Rf(array(1));");
             output.Add("$bc_iargs = array(");
             for (int rowIndex = 0; rowIndex < integers.Count; ++rowIndex)
             {
@@ -116,7 +116,7 @@ namespace Crayon.Translator.Php
                 }
                 else
                 {
-                    line.Add("array(array(");
+                    line.Add("new Rf(array(");
                     for (int i = 1; i < row.Length; ++i)
                     {
                         if (i > 1) line.Add(",");
@@ -142,17 +142,17 @@ namespace Crayon.Translator.Php
             output.AddRange(new string[] {
                 "function bytecode_get_iargs() {",
                 " global $bc_iargs;",
-                " return array($bc_iargs);",
+                " return new Rf($bc_iargs);",
                 "}",
 
                 "function bytecode_get_sargs() {",
                 " global $bc_sargs;",
-                " return array($bc_sargs);",
+                " return new Rf($bc_sargs);",
                 "}",
 
                 "function bytecode_get_ops() {",
                 " global $bc_ops;",
-                " return array($bc_ops);",
+                " return new Rf($bc_ops);",
                 "}"
             });
 

--- a/Compiler/Translator/PHP/PhpPlatform.cs
+++ b/Compiler/Translator/PHP/PhpPlatform.cs
@@ -99,9 +99,9 @@ namespace Crayon.Translator.Php
             }
             output.Add(");");
 
-            output.Add("$e = array();");
-            output.Add("$z = array(0);");
-            output.Add("$o = array(1);");
+            output.Add("$e = array(array());");
+            output.Add("$z = array(array(0));");
+            output.Add("$o = array(array(1));");
             output.Add("$bc_iargs = array(");
             for (int rowIndex = 0; rowIndex < integers.Count; ++rowIndex)
             {
@@ -116,13 +116,13 @@ namespace Crayon.Translator.Php
                 }
                 else
                 {
-                    line.Add("array(");
+                    line.Add("array(array(");
                     for (int i = 1; i < row.Length; ++i)
                     {
                         if (i > 1) line.Add(",");
                         line.Add(row[i].ToString());
                     }
-                    line.Add("),");
+                    line.Add(")),");
                 }
                 output.Add(string.Join("", line));
                 line.Clear();
@@ -140,19 +140,19 @@ namespace Crayon.Translator.Php
             }
 
             output.AddRange(new string[] {
-                "function &bytecode_get_iargs() {",
+                "function bytecode_get_iargs() {",
                 " global $bc_iargs;",
-                " return $bc_iargs;",
+                " return array($bc_iargs);",
                 "}",
 
-                "function &bytecode_get_sargs() {",
+                "function bytecode_get_sargs() {",
                 " global $bc_sargs;",
-                " return $bc_sargs;",
+                " return array($bc_sargs);",
                 "}",
 
-                "function &bytecode_get_ops() {",
+                "function bytecode_get_ops() {",
                 " global $bc_ops;",
-                " return $bc_ops;",
+                " return array($bc_ops);",
                 "}"
             });
 

--- a/Compiler/Translator/PHP/PhpSystemFunctionTranslator.cs
+++ b/Compiler/Translator/PHP/PhpSystemFunctionTranslator.cs
@@ -31,7 +31,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateArrayGet(List<string> output, Expression list, Expression index)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, index);
             output.Add("]");
         }
@@ -40,7 +40,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("count(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateArraySet(List<string> output, Expression list, Expression index, Expression value)
@@ -54,20 +54,7 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateArraySetRef(List<string> output, Expression list, Expression index, Expression value)
         {
-            this.Translator.TranslateExpression(output, list);
-            output.Add("[");
-            this.Translator.TranslateExpression(output, index);
-            output.Add("] = &");
-            if (value is Variable)
-            {
-                output.Add("array_hack(");
-                this.Translator.TranslateExpression(output, value);
-                output.Add(")");
-            }
-            else
-            {
-                this.Translator.TranslateExpression(output, value);
-            }
+            this.TranslateArraySet(output, list, index, value);
         }
 
         protected override void TranslateAssert(List<string> output, Expression message)
@@ -132,7 +119,9 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateConvertListToArray(List<string> output, StringConstant type, Expression list)
         {
+            output.Add("array(array_merge(array(), ");
             this.Translator.TranslateExpression(output, list);
+            output.Add("[0]))");
         }
 
         protected override void TranslateCos(List<string> output, Expression value)
@@ -149,7 +138,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("isset(");
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, key);
             output.Add("])");
         }
@@ -157,7 +146,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateDictionaryGetGuaranteed(List<string> output, Expression dictionary, Expression key)
         {
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, key);
             output.Add("]");
         }
@@ -165,14 +154,14 @@ namespace Crayon.Translator.Php
         protected override void TranslateDictionaryGetKeys(List<string> output, string keyType, Expression dictionary)
         {
             output.Add("pth_dictionary_get_keys(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, dictionary);
+            this.PhpTranslator.TranslateExpression(output, dictionary);
             output.Add(")");
         }
 
         protected override void TranslateDictionaryGetValues(List<string> output, Expression dictionary)
         {
             output.Add("pth_dictionary_get_values(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, dictionary);
+            this.PhpTranslator.TranslateExpression(output, dictionary);
             output.Add(")");
         }
 
@@ -180,7 +169,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("unset(");
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, key);
             output.Add("])");
         }
@@ -188,7 +177,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateDictionarySet(List<string> output, Expression dictionary, Expression key, Expression value)
         {
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, key);
             output.Add("] = ");
             this.Translator.TranslateExpression(output, value);
@@ -196,27 +185,14 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateDictionarySetRef(List<string> output, Expression dictionary, Expression key, Expression value)
         {
-            this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[");
-            this.Translator.TranslateExpression(output, key);
-            output.Add("] = &");
-            if (value is Variable)
-            {
-                output.Add("array_hack(");
-                this.Translator.TranslateExpression(output, value);
-                output.Add(")");
-            }
-            else
-            {
-                this.Translator.TranslateExpression(output, value);
-            }
+            this.TranslateDictionarySet(output, dictionary, key, value);
         }
 
         protected override void TranslateDictionarySize(List<string> output, Expression dictionary)
         {
             output.Add("count(");
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateDotEquals(List<string> output, Expression root, Expression compareTo)
@@ -373,7 +349,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateIsValidInteger(List<string> output, Expression number)
         {
             output.Add("pth_is_valid_integer(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, number);
+            this.PhpTranslator.TranslateExpression(output, number);
             output.Add(")");
         }
 
@@ -389,30 +365,30 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateListConcat(List<string> output, Expression listA, Expression listB)
         {
-            output.Add("array_merge(");
+            output.Add("array(array_merge(");
             this.Translator.TranslateExpression(output, listA);
-            output.Add(", ");
+            output.Add("[0], ");
             this.Translator.TranslateExpression(output, listB);
-            output.Add(")");
+            output.Add("[0]))");
         }
 
         protected override void TranslateListGet(List<string> output, Expression list, Expression index)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, index);
             output.Add("]");
         }
 
         protected override void TranslateListInsert(List<string> output, Expression list, Expression index, Expression value)
         {
-            output.Add("array_splice(");
+            output.Add("array(array_splice(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(", ");
+            output.Add("[0], ");
             this.Translator.TranslateExpression(output, index);
             output.Add(", 0, array(");
             this.Translator.TranslateExpression(output, value);
-            output.Add("))");
+            output.Add(")))");
         }
 
         protected override void TranslateListJoin(List<string> output, Expression list, Expression sep)
@@ -421,14 +397,14 @@ namespace Crayon.Translator.Php
             this.Translator.TranslateExpression(output, sep);
             output.Add(", ");
             this.Translator.TranslateExpression(output, list);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateListJoinChars(List<string> output, Expression list)
         {
             output.Add("implode('', ");
             this.Translator.TranslateExpression(output, list);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateListLastIndex(List<string> output, Expression list)
@@ -440,21 +416,21 @@ namespace Crayon.Translator.Php
         {
             output.Add("count(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateListPop(List<string> output, Expression list)
         {
             output.Add("array_pop(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateListPush(List<string> output, Expression list, Expression value)
         {
             output.Add("array_push(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(", ");
+            output.Add("[0], ");
             this.Translator.TranslateExpression(output, value);
             output.Add(")");
         }
@@ -463,7 +439,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("array_splice(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(", ");
+            output.Add("[0], ");
             this.Translator.TranslateExpression(output, index);
             output.Add(", 1)");
         }
@@ -471,14 +447,14 @@ namespace Crayon.Translator.Php
         protected override void TranslateListReverseInPlace(List<string> output, Expression list)
         {
             output.Add("pth_list_reverse(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, list);
+            this.PhpTranslator.TranslateExpression(output, list);
             output.Add(")");
         }
 
         protected override void TranslateListSet(List<string> output, Expression list, Expression index, Expression value)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[");
+            output.Add("[0][");
             this.Translator.TranslateExpression(output, index);
             output.Add("] = ");
             this.Translator.TranslateExpression(output, value);
@@ -488,39 +464,39 @@ namespace Crayon.Translator.Php
         {
             output.Add("shuffle(");
             this.Translator.TranslateExpression(output, list);
-            output.Add(")");
+            output.Add("[0])");
         }
 
         protected override void TranslateMultiplyList(List<string> output, Expression list, Expression num)
         {
             output.Add("pth_multiply_list(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, list);
+            this.PhpTranslator.TranslateExpression(output, list);
             output.Add(", ");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, num);
+            this.PhpTranslator.TranslateExpression(output, num);
             output.Add(")");
         }
 
         protected override void TranslateNewArray(List<string> output, StringConstant type, Expression size)
         {
             output.Add("pth_new_array(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, size);
+            this.PhpTranslator.TranslateExpression(output, size);
             output.Add(")");
         }
 
         protected override void TranslateNewDictionary(List<string> output, StringConstant keyType, StringConstant valueType)
         {
-            output.Add("array()");
+            output.Add("array(array())");
         }
 
         protected override void TranslateNewList(List<string> output, StringConstant type)
         {
-            output.Add("array()");
+            output.Add("array(array())");
         }
 
         protected override void TranslateNewListOfSize(List<string> output, StringConstant type, Expression length)
         {
             output.Add("pth_new_array(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, length);
+            this.PhpTranslator.TranslateExpression(output, length);
             output.Add(")");
         }
 
@@ -534,9 +510,9 @@ namespace Crayon.Translator.Php
         protected override void TranslateParseFloat(List<string> output, Expression outParam, Expression rawString)
         {
             output.Add("pth_parse_float(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, outParam);
+            this.PhpTranslator.TranslateExpression(output, outParam);
             output.Add(", ");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, rawString);
+            this.PhpTranslator.TranslateExpression(output, rawString);
             output.Add(")");
         }
 
@@ -550,7 +526,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateParseJson(List<string> output, Expression rawString)
         {
             output.Add("pth_parse_json(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, rawString);
+            this.PhpTranslator.TranslateExpression(output, rawString);
             output.Add(")");
         }
 
@@ -592,7 +568,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateSetProgramData(List<string> output, Expression programData)
         {
             output.Add("pth_setProgramData(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, programData);
+            this.PhpTranslator.TranslateExpression(output, programData);
             output.Add(")");
         }
 
@@ -609,14 +585,14 @@ namespace Crayon.Translator.Php
         protected override void TranslateSortedCopyOfIntArray(List<string> output, Expression list)
         {
             output.Add("pth_sorted_copy_ints(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, list);
+            this.PhpTranslator.TranslateExpression(output, list);
             output.Add(")");
         }
 
         protected override void TranslateSortedCopyOfStringArray(List<string> output, Expression list)
         {
             output.Add("pth_sorted_copy_strings(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, list);
+            this.PhpTranslator.TranslateExpression(output, list);
             output.Add(")");
         }
 
@@ -684,18 +660,18 @@ namespace Crayon.Translator.Php
         protected override void TranslateStringContains(List<string> output, Expression haystack, Expression needle)
         {
             output.Add("pth_string_contains(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, haystack);
+            this.PhpTranslator.TranslateExpression(output, haystack);
             output.Add(", ");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, needle);
+            this.PhpTranslator.TranslateExpression(output, needle);
             output.Add(")");
         }
 
         protected override void TranslateStringEndsWith(List<string> output, Expression stringExpr, Expression findMe)
         {
             output.Add("pth_string_ends_with(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, stringExpr);
+            this.PhpTranslator.TranslateExpression(output, stringExpr);
             output.Add(", ");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, findMe);
+            this.PhpTranslator.TranslateExpression(output, findMe);
             output.Add(")");
         }
 
@@ -718,9 +694,9 @@ namespace Crayon.Translator.Php
         protected override void TranslateStringIndexOf(List<string> output, Expression haystack, Expression needle)
         {
             output.Add("pth_string_index_of(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, haystack);
+            this.PhpTranslator.TranslateExpression(output, haystack);
             output.Add(", ");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, needle);
+            this.PhpTranslator.TranslateExpression(output, needle);
             output.Add(")");
         }
 
@@ -773,19 +749,19 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateStringSplit(List<string> output, Expression stringExpr, Expression sep)
         {
-            output.Add("explode(");
+            output.Add("array(explode(");
             this.Translator.TranslateExpression(output, sep);
             output.Add(", ");
             this.Translator.TranslateExpression(output, stringExpr);
-            output.Add(")");
+            output.Add("))");
         }
 
         protected override void TranslateStringStartsWith(List<string> output, Expression stringExpr, Expression findMe)
         {
             output.Add("pth_string_starts_with(");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, stringExpr);
+            this.PhpTranslator.TranslateExpression(output, stringExpr);
             output.Add(", ");
-            this.PhpTranslator.ArgSafeTranslateExpression(output, findMe);
+            this.PhpTranslator.TranslateExpression(output, findMe);
             output.Add(")");
         }
 

--- a/Compiler/Translator/PHP/PhpSystemFunctionTranslator.cs
+++ b/Compiler/Translator/PHP/PhpSystemFunctionTranslator.cs
@@ -31,7 +31,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateArrayGet(List<string> output, Expression list, Expression index)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, index);
             output.Add("]");
         }
@@ -40,13 +40,13 @@ namespace Crayon.Translator.Php
         {
             output.Add("count(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateArraySet(List<string> output, Expression list, Expression index, Expression value)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, index);
             output.Add("] = ");
             this.Translator.TranslateExpression(output, value);
@@ -119,9 +119,9 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateConvertListToArray(List<string> output, StringConstant type, Expression list)
         {
-            output.Add("array(array_merge(array(), ");
+            output.Add("new Rf(array_merge(array(), ");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0]))");
+            output.Add("->r))");
         }
 
         protected override void TranslateCos(List<string> output, Expression value)
@@ -138,7 +138,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("isset(");
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, key);
             output.Add("])");
         }
@@ -146,7 +146,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateDictionaryGetGuaranteed(List<string> output, Expression dictionary, Expression key)
         {
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, key);
             output.Add("]");
         }
@@ -169,7 +169,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("unset(");
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, key);
             output.Add("])");
         }
@@ -177,7 +177,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateDictionarySet(List<string> output, Expression dictionary, Expression key, Expression value)
         {
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, key);
             output.Add("] = ");
             this.Translator.TranslateExpression(output, value);
@@ -192,7 +192,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("count(");
             this.Translator.TranslateExpression(output, dictionary);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateDotEquals(List<string> output, Expression root, Expression compareTo)
@@ -365,26 +365,26 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateListConcat(List<string> output, Expression listA, Expression listB)
         {
-            output.Add("array(array_merge(");
+            output.Add("new Rf(array_merge(");
             this.Translator.TranslateExpression(output, listA);
-            output.Add("[0], ");
+            output.Add("->r, ");
             this.Translator.TranslateExpression(output, listB);
-            output.Add("[0]))");
+            output.Add("->r))");
         }
 
         protected override void TranslateListGet(List<string> output, Expression list, Expression index)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, index);
             output.Add("]");
         }
 
         protected override void TranslateListInsert(List<string> output, Expression list, Expression index, Expression value)
         {
-            output.Add("array(array_splice(");
+            output.Add("new Rf(array_splice(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0], ");
+            output.Add("->r, ");
             this.Translator.TranslateExpression(output, index);
             output.Add(", 0, array(");
             this.Translator.TranslateExpression(output, value);
@@ -397,14 +397,14 @@ namespace Crayon.Translator.Php
             this.Translator.TranslateExpression(output, sep);
             output.Add(", ");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateListJoinChars(List<string> output, Expression list)
         {
             output.Add("implode('', ");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateListLastIndex(List<string> output, Expression list)
@@ -416,21 +416,21 @@ namespace Crayon.Translator.Php
         {
             output.Add("count(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateListPop(List<string> output, Expression list)
         {
             output.Add("array_pop(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateListPush(List<string> output, Expression list, Expression value)
         {
             output.Add("array_push(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0], ");
+            output.Add("->r, ");
             this.Translator.TranslateExpression(output, value);
             output.Add(")");
         }
@@ -439,7 +439,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("array_splice(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0], ");
+            output.Add("->r, ");
             this.Translator.TranslateExpression(output, index);
             output.Add(", 1)");
         }
@@ -454,7 +454,7 @@ namespace Crayon.Translator.Php
         protected override void TranslateListSet(List<string> output, Expression list, Expression index, Expression value)
         {
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0][");
+            output.Add("->r[");
             this.Translator.TranslateExpression(output, index);
             output.Add("] = ");
             this.Translator.TranslateExpression(output, value);
@@ -464,7 +464,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("shuffle(");
             this.Translator.TranslateExpression(output, list);
-            output.Add("[0])");
+            output.Add("->r)");
         }
 
         protected override void TranslateMultiplyList(List<string> output, Expression list, Expression num)
@@ -485,12 +485,12 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateNewDictionary(List<string> output, StringConstant keyType, StringConstant valueType)
         {
-            output.Add("array(array())");
+            output.Add("new Rf(array())");
         }
 
         protected override void TranslateNewList(List<string> output, StringConstant type)
         {
-            output.Add("array(array())");
+            output.Add("new Rf(array())");
         }
 
         protected override void TranslateNewListOfSize(List<string> output, StringConstant type, Expression length)
@@ -749,7 +749,7 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateStringSplit(List<string> output, Expression stringExpr, Expression sep)
         {
-            output.Add("array(explode(");
+            output.Add("new Rf(explode(");
             this.Translator.TranslateExpression(output, sep);
             output.Add(", ");
             this.Translator.TranslateExpression(output, stringExpr);

--- a/Compiler/Translator/PHP/PhpTranslator.cs
+++ b/Compiler/Translator/PHP/PhpTranslator.cs
@@ -35,7 +35,7 @@ namespace Crayon.Translator.Php
         {
             output.Add("$");
             output.Add(dotStepStruct.RootVar);
-            output.Add("[0][");
+            output.Add("->r[");
             output.Add(dotStepStruct.StructDefinition.IndexByField[dotStepStruct.FieldName].ToString());
             output.Add("]");
         }
@@ -112,7 +112,7 @@ namespace Crayon.Translator.Php
 
         protected override void TranslateStructInstance(List<string> output, StructInstance structInstance)
         {
-            output.Add("array(array(");
+            output.Add("new Rf(array(");
             for (int i = 0; i < structInstance.Args.Length; ++i)
             {
                 if (i > 0) output.Add(", ");

--- a/Compiler/Translator/PHP/PhpTranslator.cs
+++ b/Compiler/Translator/PHP/PhpTranslator.cs
@@ -7,20 +7,6 @@ namespace Crayon.Translator.Php
     internal class PhpTranslator : CurlyBraceImplementation
     {
         public PhpTranslator() : base(true) { }
-
-        public override string GetAssignmentOp(Assignment assignment)
-        {
-            string output = assignment.AssignmentOp;
-            if (output == ":=") return "= &";
-            return output + " ";
-        }
-
-        public bool IsTypeReference(string type)
-        {
-            // I should be embarrassed, but oddly proud of this one-liner.
-            // I'll eat my pride when this breaks royally a year down the road.
-            return type[0] < 'a' || type[0] > 'z';
-        }
         
         protected override void TranslateAssignment(List<string> output, Assignment assignment)
         {
@@ -28,31 +14,28 @@ namespace Crayon.Translator.Php
             this.TranslateExpression(output, assignment.Target);
             output.Add(" ");
             output.Add(this.GetAssignmentOp(assignment));
-            if (assignment.Value is NullConstant)
-            {
-                output.Add("&$nullhack");
-            }
-            else if (assignment.Value is Variable)
-            {
-                // TODO: I honestly don't know if this is necessary. Once this is all in a more
-                // stable state, remove this and see if everything still works.
-                output.Add("array_hack(");
-                this.TranslateExpression(output, assignment.Value);
-                output.Add(")");
-            }
-            else
-            {
-                this.TranslateExpression(output, assignment.Value);
-            }
+            output.Add(" ");
+            this.TranslateExpression(output, assignment.Value);
             output.Add(";");
             output.Add(this.NL);
+        }
+
+        protected override void TranslateBinaryOpSyntax(List<string> output, string tokenValue)
+        {
+            switch (tokenValue)
+            {
+                case "==": tokenValue = "==="; break;
+                case "!=": tokenValue = "!=="; break;
+                default: break;
+            }
+            output.Add(tokenValue);
         }
 
         protected override void TranslateDotStepStruct(List<string> output, DotStepStruct dotStepStruct)
         {
             output.Add("$");
             output.Add(dotStepStruct.RootVar);
-            output.Add("[");
+            output.Add("[0][");
             output.Add(dotStepStruct.StructDefinition.IndexByField[dotStepStruct.FieldName].ToString());
             output.Add("]");
         }
@@ -71,10 +54,6 @@ namespace Crayon.Translator.Php
             {
                 throw new ParserException(functionDef.FirstToken, "Need return type.");
             }
-            if (this.IsTypeReference(type))
-            {
-                output.Add("&");
-            }
             output.Add("v_");
             output.Add(functionDef.NameToken.Value);
             output.Add("(");
@@ -85,11 +64,6 @@ namespace Crayon.Translator.Php
                 if (annotation == null)
                 {
                     throw new ParserException(functionDef.FirstToken, "Arg needs a type.");
-                }
-                string argType = annotation == null ? "Object" : annotation.GetSingleArgAsString(null);
-                if (this.IsTypeReference(argType))
-                {
-                    output.Add("&");
                 }
                 output.Add("$v_" + functionDef.ArgNames[i].Value);
             }
@@ -113,8 +87,6 @@ namespace Crayon.Translator.Php
                 output.Add(variable);
                 output.Add(";\n");
             }
-            output.Add(this.CurrentTabIndention);
-            output.Add("global $nullhack;\n");
 
             foreach (Executable line in functionDef.Code)
             {
@@ -124,31 +96,7 @@ namespace Crayon.Translator.Php
             output.Add(this.CurrentTabIndention);
             output.Add("}\n");
         }
-
-        public void ArgSafeTranslateExpression(List<string> output, Expression expression)
-        {
-            if (expression is NullConstant)
-            {
-                output.Add("$nullhack");
-            }
-            else
-            {
-                List<string> buffer = new List<string>();
-                this.TranslateExpression(buffer, expression);
-                string value = string.Join("", buffer);
-                if (value.StartsWith("array(") && value.EndsWith(")"))
-                {
-                    output.Add("array_hack(");
-                    output.Add(value);
-                    output.Add(")");
-                }
-                else
-                {
-                    output.Add(value);
-                }
-            }
-        }
-
+        
         protected override void TranslateFunctionCall(List<string> output, FunctionCall functionCall)
         {
             Variable func = (Variable)functionCall.Root;
@@ -157,20 +105,20 @@ namespace Crayon.Translator.Php
             for (int i = 0; i < functionCall.Args.Length; ++i)
             {
                 if (i > 0) output.Add(", ");
-                this.ArgSafeTranslateExpression(output, functionCall.Args[i]);
+                this.TranslateExpression(output, functionCall.Args[i]);
             }
             output.Add(")");
         }
 
         protected override void TranslateStructInstance(List<string> output, StructInstance structInstance)
         {
-            output.Add("array(");
+            output.Add("array(array(");
             for (int i = 0; i < structInstance.Args.Length; ++i)
             {
                 if (i > 0) output.Add(", ");
                 this.TranslateExpression(output, structInstance.Args[i]);
             }
-            output.Add(")");
+            output.Add("))");
         }
 
         protected override void TranslateVariable(List<string> output, Variable expr)

--- a/Interpreter/ByteCodeLoader.cry
+++ b/Interpreter/ByteCodeLoader.cry
@@ -55,7 +55,7 @@ function @type('int') read_integer(@type('Array<int>') pindex, @type('string') r
 	return num;
 }
 
-function @type('string') read_string(@type('Array<int>') pindex, @type('string') raw, @type('int') length) {
+function @type('string') read_string(@type('Array<int>') pindex, @type('string') raw, @type('int') length, @type('string') alphaNums) {
 	@type('List<string>') output = $_new_list('string');
 	if (!%%%IS_BYTECODE_LOADED_DIRECTLY%%%) {
 		@type('bool') cont = true;
@@ -153,7 +153,7 @@ function @type('Code') loadByteCode() {
 			}
 			$_array_set(iargs, i, iarglist);
 			if (stringPresent) {
-				stringarg = read_string(index, raw, length);
+				stringarg = read_string(index, raw, length, alphaNums);
 			} else {
 				stringarg = null;
 			}

--- a/Interpreter/Ops/deref_dot.cry
+++ b/Interpreter/Ops/deref_dot.cry
@@ -38,7 +38,12 @@ switch (Value$value.type) {
 
 	case Types.LIST:
 		if (ProgramData$p.lengthId == nameId) {
-			int2 = $_list_length($_force_parens($_cast('List<Value>', Value$value.internalValue)));
+			if (%%%IS_PHP%%%) {
+				// The harmless force_parens confuses PHP because YOU CAN'T DEREFERENCE A LIST IF IT'S IN PARENTHESIS IN PHP.
+				int2 = $_list_length($_cast('List<Value>', Value$value.internalValue));
+			} else {
+				int2 = $_list_length($_force_parens($_cast('List<Value>', Value$value.internalValue)));
+			}
 			output := buildInteger(int2);
 		} else {
 			string1 = "list";

--- a/Interpreter/ValueUtil.cry
+++ b/Interpreter/ValueUtil.cry
@@ -87,11 +87,11 @@ function @type('int') initialize_constant_values() {
 function @type('Value') buildInteger(@type('int') num) {
 	if (num < 0) {
 		if (num > -INTEGER_NEGATIVE_CACHE) {
-			return INTEGERS_CACHE[1][-num];
+			return $_array_get($_array_get(INTEGERS_CACHE, 1), -num);
 		}
 	} else {
 		if (num < INTEGER_POSITIVE_CACHE) {
-			return INTEGERS_CACHE[0][num];
+			return $_array_get($_array_get(INTEGERS_CACHE, 0), num);
 		}
 	}
 	return new Value(Types.INTEGER, num);

--- a/Libraries/HttpServer/embed.cry
+++ b/Libraries/HttpServer/embed.cry
@@ -20,5 +20,9 @@
 		constructor(vars) {
 			this._basic_vars = vars;
 		}
+		
+		function getMethod() { return this._basic_vars[0]; }
+		function getPath() { return this._basic_vars[1]; }
+		function getIp() { return this._basic_vars[2]; }
 	}
 }

--- a/Resources/php-server/cryutil.php
+++ b/Resources/php-server/cryutil.php
@@ -1,48 +1,43 @@
 ﻿<?php
-  $nullhack = null;
-  
-  function &array_hack($array) { return $array; }
   
   function pth_noop() { }
   
-	function &pth_new_array($size) {
+	function pth_new_array($size) {
     $output = array();
     while ($size-- > 0) array_push($output, null);
-    return $output;
+    return array($output);
   }
   
-  function &pth_dictionary_get_keys(&$dictionary) {
+  function pth_dictionary_get_keys($dictionary) {
     $output = array();
-    foreach ($dictionary as $key => $ignored) {
+    foreach ($dictionary[0] as $key => $ignored) {
       array_push($output, $key);
     }
-    return $output;
+    return array($output);
   }
   
   $pth_program_data = null;
-  function pth_setProgramData(&$pd) {
-    $GLOBALS['pth_program_data'] = &$pd;
+  function pth_setProgramData($pd) {
+    $GLOBALS['pth_program_data'] = $pd;
   }
   
-  function &pth_getProgramData() {
+  function pth_getProgramData() {
     return $GLOBALS['pth_program_data'];
   }
   
-  function pth_list_reverse(&$list) {
-    $length = count($list);
+  function pth_list_reverse($list) {
+    $length = count($list[0]);
     for ($i = intval($length / 2) - 1; $i >= 0; --$i) {
       $j = $length - $i - 1;
-      $refLeft = is_array($list[$i]);
-      $refRight = is_array($list[$j]);
-      if ($refLeft) $t = &$list[$i]; else $t = $list[$i];
-      if ($refRight) $list[$i] = &$list[$j]; else $list[$i] = $list[$j];
-      if ($refLeft) $list[$j] = &$t; else $list[$j] = $t;
+      $t = $list[0][$i];
+      $list[0][$i] = $list[0][$j];
+      $list[0][$j] = $t;
     }
   }
   
-  function pth_getHttpRequest(&$stringOut) {
-    $stringOut[0] = $_SERVER['REQUEST_METHOD'];
-    $stringOut[1] = $_SERVER['REQUEST_URI'];
-    $stringOut[2] = $_SERVER['REMOTE_HOST'];
+  function pth_getHttpRequest($stringOut) {
+    $stringOut[0][0] = $_SERVER['REQUEST_METHOD'];
+    $stringOut[0][1] = $_SERVER['REQUEST_URI'];
+    $stringOut[0][2] = $_SERVER['REMOTE_HOST'];
   }
 ?>

--- a/Resources/php-server/cryutil.php
+++ b/Resources/php-server/cryutil.php
@@ -1,19 +1,26 @@
 ﻿<?php
   
+  class Rf {
+    public $r;
+    function __construct($value) {
+      $this->r = $value;
+    }
+  }
+  
   function pth_noop() { }
   
 	function pth_new_array($size) {
     $output = array();
     while ($size-- > 0) array_push($output, null);
-    return array($output);
+    return new Rf($output);
   }
   
   function pth_dictionary_get_keys($dictionary) {
     $output = array();
-    foreach ($dictionary[0] as $key => $ignored) {
+    foreach ($dictionary->r as $key => $ignored) {
       array_push($output, $key);
     }
-    return array($output);
+    return new Rf($output);
   }
   
   $pth_program_data = null;
@@ -26,18 +33,18 @@
   }
   
   function pth_list_reverse($list) {
-    $length = count($list[0]);
+    $length = count($list->r);
     for ($i = intval($length / 2) - 1; $i >= 0; --$i) {
       $j = $length - $i - 1;
-      $t = $list[0][$i];
-      $list[0][$i] = $list[0][$j];
-      $list[0][$j] = $t;
+      $t = $list->r[$i];
+      $list->r[$i] = $list->r[$j];
+      $list->r[$j] = $t;
     }
   }
   
   function pth_getHttpRequest($stringOut) {
-    $stringOut[0][0] = $_SERVER['REQUEST_METHOD'];
-    $stringOut[0][1] = $_SERVER['REQUEST_URI'];
-    $stringOut[0][2] = $_SERVER['REMOTE_HOST'];
+    $stringOut->r[0] = $_SERVER['REQUEST_METHOD'];
+    $stringOut->r[1] = $_SERVER['REQUEST_URI'];
+    $stringOut->r[2] = $_SERVER['REMOTE_HOST'];
   }
 ?>

--- a/Resources/php-server/index.php
+++ b/Resources/php-server/index.php
@@ -1,6 +1,6 @@
 ﻿<?php
-	require 'bytecode.php';
 	require 'cryutil.php';
+	require 'bytecode.php';
 	require 'crayon.php';
 
 	v_main();


### PR DESCRIPTION
Bulldozing all the madness in the php branch with a slightly memory-intensive solution that gracefully allows all the translated code to just work as-is without doing wacky stuff that'll double the test matrix (PHP vs non-PHP platforms). 