### PR TITLE
OSX setup instructions & build

### DIFF
--- a/Compiler/CrayonOSX.csproj
+++ b/Compiler/CrayonOSX.csproj
@@ -49,6 +49,11 @@
     <Compile Include="*.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="LICENSE.txt">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\Interpreter\Interpreter.csproj">
       <Project>{B7D7C85B-96CE-4FD5-9653-CC9BCE291363}</Project>
       <Name>Interpreter</Name>

--- a/Release/release.py
+++ b/Release/release.py
@@ -68,7 +68,7 @@ for platform in ('windows', 'mono'):
 		setupFile = readFile("setup-windows.txt")
 		writeFile(copyToDir + '/Setup Instructions.txt', setupFile, '\r\n')
 	if platform == 'mono':
-		setupFile = readFile("setup-mono.txt")
+		setupFile = readFile("setup-mono.md")
 		writeFile(copyToDir + '/Setup Instructions.txt', setupFile, '\n')
 
 	for lib in librariesForRelease:

--- a/Release/setup-mono.md
+++ b/Release/setup-mono.md
@@ -1,0 +1,19 @@
+FOR OSX:
+
+In the following steps `$CPD` will represent the directory that the Crayon product has been cloned into.
+
+1. Install mono: http://www.mono-project.com/docs/about-mono/supported-platforms/osx/
+
+2. Change the build target to `Release`: `$CPD> sed -i -e 's/\(.*Configuration Condition.*\)Debug\(.*\)/\1Release\2/' Compiler/CrayonOSX.csproj`
+
+3. Compile the Crayon compiler: `$CPD> xbuild Compiler/CrayonOSX.csproj`
+
+4. Run the Release script: `$CPD/Release> python release.py`
+
+5. Copy the resulting directory (`crayon-VERSION-mono`) to the desired install location and update `$CRAYON_HOME` to point to this directory.
+
+6. Optional: add an alias that will run the compiler, I use: `alias cryc='mono $CRAYON_HOME/crayon.exe'`
+
+
+FOR LINUX:
+- (TODO)

--- a/Release/setup-mono.txt
+++ b/Release/setup-mono.txt
@@ -1,6 +1,0 @@
-FOR OSX:
-- (TODO)
-
-
-FOR LINUX:
-- (TODO)


### PR DESCRIPTION
This adds a walkthrough on getting crayon up and running on OSX and fixes a bug in the build file along the way.