### PR TITLE
Fix static analysis issues

### DIFF
--- a/Common/ImageSheets/RectangleAllocator.cs
+++ b/Common/ImageSheets/RectangleAllocator.cs
@@ -81,9 +81,7 @@ namespace Common.ImageSheets
                     {
                         // move to the next row.
                         x = 0;
-                        var temp = topY;
                         topY = bottomY;
-                        bottomY = temp;
                     }
 
                     bottomY = System.Math.Max(bottomY, topY + currentImage.Height);

--- a/Common/ImageSheets/RectangleAllocator.cs
+++ b/Common/ImageSheets/RectangleAllocator.cs
@@ -81,8 +81,9 @@ namespace Common.ImageSheets
                     {
                         // move to the next row.
                         x = 0;
+                        var temp = topY;
                         topY = bottomY;
-                        bottomY = topY;
+                        bottomY = temp;
                     }
 
                     bottomY = System.Math.Max(bottomY, topY + currentImage.Height);

--- a/Compiler/Program.cs
+++ b/Compiler/Program.cs
@@ -290,8 +290,6 @@ namespace Crayon
 
                 BuildContext buildContext = null;
 
-                projectDirectory = FileUtil.GetParentDirectory(buildFile);
-
                 buildContext = BuildContext.Parse(projectDirectory, FileUtil.ReadFileText(buildFile), target);
 
                 buildContext = buildContext ?? new BuildContext();

--- a/Exporter/ByteCodeEncoder.cs
+++ b/Exporter/ByteCodeEncoder.cs
@@ -95,7 +95,7 @@ namespace Crayon
         {
             if (SAFE_CHARS.Contains(c)) return "" + c;
 
-            if (c >= 0 && c < 62 * 62)
+            if (c < 62 * 62)
             {
                 return "~" + BASE62[c / 62] + BASE62[c % 62];
             }

--- a/Parser/ParseTree/IntegerConstant.cs
+++ b/Parser/ParseTree/IntegerConstant.cs
@@ -61,7 +61,7 @@ namespace Parser.ParseTree
             {
                 foreach (char c in value)
                 {
-                    if (c < '0' && c > '9') throw new ParserException(token, "Invalid integer constant.");
+                    if (c < '0' || c > '9') throw new ParserException(token, "Invalid integer constant.");
                     number = number * 10 + (c - '0');
                 }
             }


### PR DESCRIPTION
- [V3022](https://www.viva64.com/en/w/V3022) Expression 'c < '0' && c > '9'' is always false. Probably the '||' operator should be used here. IntegerConstant.cs 64
- [V3037](https://www.viva64.com/en/w/V3037) An odd sequence of assignments of this kind: A = B; B = A;. Check lines: 85, 84. RectangleAllocator.cs 85
- [V3063](https://www.viva64.com/en/w/V3063) A part of conditional expression is always true if it is evaluated: c >= 0. ByteCodeEncoder.cs 98
- [V3008](https://www.viva64.com/en/w/V3008) The 'projectDirectory' variable is assigned values twice successively. Perhaps this is a mistake. Check lines: 293, 289. Program.cs 293

Analysed using [PVS-Studio](https://www.viva64.com/en/pvs-studio/) as a part of [pinguem.ru](https://pinguem.ru) competition