### PR TITLE
Add more consistency to modifier parsing.

### DIFF
--- a/Compiler/Parser/ModifierCollection.cs
+++ b/Compiler/Parser/ModifierCollection.cs
@@ -5,27 +5,108 @@ namespace Parser
 {
     public class ModifierCollection
     {
-        public Dictionary<string, Token> modifierTokens;
-        public Token FirstToken { get; private set; }
-
         public static readonly ModifierCollection EMPTY = new ModifierCollection(new Token[0]);
 
-        public ModifierCollection(IList<Token> modifiers)
+        private enum ModifierType
+        {
+            ABSTRACT = 0,
+            FINAL = 1,
+            INTERNAL = 2,
+            OVERRIDE = 3,
+            PRIVATE = 4,
+            PROTECTED = 5,
+            PUBLIC = 6,
+            STATIC = 7,
+
+            MAX = 8,
+        }
+
+        private static readonly Dictionary<string, ModifierType> LOOKUP = new Dictionary<string, ModifierType>()
+        {
+            { "abstract", ModifierType.ABSTRACT },
+            { "final", ModifierType.FINAL },
+            { "internal", ModifierType.INTERNAL},
+            { "private", ModifierType.PRIVATE },
+            { "protected", ModifierType.PROTECTED },
+            { "public", ModifierType.PUBLIC },
+            { "override", ModifierType.OVERRIDE },
+            { "static", ModifierType.STATIC },
+        };
+
+        private Token[] tokens = new Token[(int)ModifierType.MAX];
+        public Token FirstToken { get; private set; }
+
+        public static ModifierCollection Parse(TokenStream tokens)
+        {
+            if (!tokens.HasMore || !LOOKUP.ContainsKey(tokens.PeekValue()))
+            {
+                return EMPTY;
+            }
+
+            List<Token> modifierTokens = new List<Token>();
+            while (LOOKUP.ContainsKey(tokens.PeekValue()))
+            {
+                modifierTokens.Add(tokens.Pop());
+            }
+            return new ModifierCollection(modifierTokens);
+        }
+
+        private ModifierCollection(IList<Token> modifiers)
         {
             this.FirstToken = modifiers.Count == 0 ? null : modifiers[0];
 
-            // TODO: throw error if duplicates
-            this.modifierTokens = modifiers.ToDictionary(token => token.Value);
+            foreach (Token token in modifiers)
+            {
+                int index = (int)LOOKUP[token.Value];
+                if (this.tokens[index] != null) throw new ParserException(token, "Multiple declarations of '" + token.Value + "' have occurred.");
+                this.tokens[index] = token;
+            }
+
+            if (modifiers.Count > 1)
+            {
+                int accessModifierCount =
+                    (this.HasPublic ? 1 : 0) +
+                    (this.HasPrivate ? 1 : 0) +
+                    (this.HasInternal ? 1 : 0) +
+                    (this.HasProtected ? 1 : 0);
+
+                if (accessModifierCount > 1 && (accessModifierCount != 2 || !this.HasProtected || !this.HasInternal))
+                {
+                    throw new ParserException(
+                        this.PublicToken ?? this.PrivateToken ?? this.InternalToken,
+                        "Multiple access modifiers are not allowed (with the exception of internal + protected");
+                }
+            }
+
+            if (this.HasFinal && this.HasAbstract)
+            {
+                throw new ParserException(this.FinalToken, "Entity cannot be both final and abstract.");
+            }
         }
 
         public static ModifierCollection CreateStaticModifier(Token aToken)
         {
             ModifierCollection modifiers = new ModifierCollection(new Token[0]);
             modifiers.FirstToken = aToken;
-            modifiers.modifierTokens["static"] = aToken;
+            modifiers.tokens[(int)ModifierType.STATIC] = aToken;
             return modifiers;
         }
 
-        public bool HasStatic { get { return this.modifierTokens.ContainsKey("static"); } }
+        public bool HasAbstract { get { return this.tokens[(int)ModifierType.ABSTRACT] != null; } }
+        public Token AbstractToken { get { return this.tokens[(int)ModifierType.ABSTRACT]; } }
+        public bool HasFinal { get { return this.tokens[(int)ModifierType.FINAL] != null; } }
+        public Token FinalToken { get { return this.tokens[(int)ModifierType.FINAL]; } }
+        public bool HasInternal { get { return this.tokens[(int)ModifierType.INTERNAL] != null; } }
+        public Token InternalToken { get { return this.tokens[(int)ModifierType.INTERNAL]; } }
+        public bool HasOverride { get { return this.tokens[(int)ModifierType.OVERRIDE] != null; } }
+        public Token OverrideToken { get { return this.tokens[(int)ModifierType.OVERRIDE]; } }
+        public bool HasPrivate { get { return this.tokens[(int)ModifierType.PRIVATE] != null; } }
+        public Token PrivateToken { get { return this.tokens[(int)ModifierType.PRIVATE]; } }
+        public bool HasProtected { get { return this.tokens[(int)ModifierType.PROTECTED] != null; } }
+        public Token ProtectedToken { get { return this.tokens[(int)ModifierType.PROTECTED]; } }
+        public bool HasPublic { get { return this.tokens[(int)ModifierType.PUBLIC] != null; } }
+        public Token PublicToken { get { return this.tokens[(int)ModifierType.PUBLIC]; } }
+        public bool HasStatic { get { return this.tokens[(int)ModifierType.STATIC] != null; } }
+        public Token StaticToken { get { return this.tokens[(int)ModifierType.STATIC]; } }
     }
 }

--- a/Compiler/Parser/ParseTree/ClassDefinition.cs
+++ b/Compiler/Parser/ParseTree/ClassDefinition.cs
@@ -24,6 +24,7 @@ namespace Parser.ParseTree
         public Token FinalToken { get; set; }
 
         private bool memberIdsResolved = false;
+        public ModifierCollection Modifiers { get; private set; }
         private AnnotationCollection annotations;
 
         // When a variable in this class is not locally defined, look for a fully qualified name that has one of these prefixes.
@@ -37,9 +38,8 @@ namespace Parser.ParseTree
             IList<Token> subclassTokens,
             IList<string> subclassNames,
             Node owner,
-            Token staticToken,
-            Token finalToken,
             FileScope fileScope,
+            ModifierCollection modifiers,
             AnnotationCollection annotations)
             : base(classToken, owner, fileScope)
         {
@@ -48,13 +48,13 @@ namespace Parser.ParseTree
             this.NameToken = nameToken;
             this.BaseClassTokens = subclassTokens.ToArray();
             this.BaseClassDeclarations = subclassNames.ToArray();
-            this.StaticToken = staticToken;
-            this.FinalToken = finalToken;
+            this.StaticToken = modifiers.StaticToken;
+            this.FinalToken = modifiers.FinalToken;
             this.annotations = annotations;
 
-            if (staticToken != null && this.BaseClassTokens.Length > 0)
+            if (this.StaticToken != null && this.BaseClassTokens.Length > 0)
             {
-                throw new ParserException(staticToken, "Class cannot be static and have base classes or interfaces.");
+                throw new ParserException(this.StaticToken, "Class cannot be static and have base classes or interfaces.");
             }
         }
 

--- a/Compiler/Parser/ParseTree/FieldDefinition.cs
+++ b/Compiler/Parser/ParseTree/FieldDefinition.cs
@@ -16,16 +16,24 @@ namespace Parser.ParseTree
         public AType FieldType { get; private set; }
         public ResolvedType ResolvedFieldType { get; private set; }
 
-        public FieldDefinition(Token fieldToken, AType fieldType, Token nameToken, ClassDefinition owner, bool isStatic, AnnotationCollection annotations)
+        public FieldDefinition(
+            Token fieldToken,
+            AType fieldType,
+            Token nameToken,
+            ClassDefinition owner,
+            ModifierCollection modifiers,
+            AnnotationCollection annotations)
             : base(fieldToken, owner, owner.FileScope)
         {
             this.NameToken = nameToken;
             this.FieldType = fieldType;
             this.DefaultValue = null;
-            this.IsStaticField = isStatic;
+            this.IsStaticField = modifiers.HasStatic;
             this.MemberID = -1;
             this.Annotations = annotations;
             this.Lambdas = new List<Lambda>();
+
+            if (modifiers.HasAbstract) throw new ParserException(modifiers.AbstractToken, "Fields cannot be abstract.");
         }
 
         public override string GetFullyQualifiedLocalizedName(Locale locale)

--- a/Compiler/Parser/ParseTree/FunctionDefinition.cs
+++ b/Compiler/Parser/ParseTree/FunctionDefinition.cs
@@ -29,14 +29,14 @@ namespace Parser.ParseTree
             Token functionToken,
             AType returnType,
             TopLevelEntity nullableOwner,
-            bool isStaticMethod,
             Token nameToken,
+            ModifierCollection modifiers,
             AnnotationCollection annotations,
             FileScope fileScope)
             : base(functionToken, nullableOwner, fileScope)
         {
             this.ReturnType = returnType;
-            this.IsStaticMethod = isStaticMethod;
+            this.IsStaticMethod = modifiers.HasStatic;
             this.NameToken = nameToken;
             this.Annotations = annotations;
             this.MemberID = -1;


### PR DESCRIPTION
Everything uses ModifierCollection.Parse() now. By doing so, this introduces all modifiers to both Crayon and Acrylic to all entity types (unless explicitly prohibited such as an abstract field).

This removes most (all, hopefully?) instances of specifically popping a static token from an entity's parsing logic.