### PR TITLE
Crayon compiler was using {git source}/Interpreter/gen files to expor…

### DIFF
--- a/Compiler/Common/CryPkgDecoder.cs
+++ b/Compiler/Common/CryPkgDecoder.cs
@@ -78,7 +78,8 @@ namespace Common
 
         public byte[] ReadFileBytes(string path)
         {
-            if (!this.files.ContainsKey(path) || this.files[path].IsDirectory) throw new InvalidOperationException();
+            if (path.StartsWith("./")) path = path.Substring(2);
+            if (!this.files.ContainsKey(path) || this.files[path].IsDirectory) throw new InvalidOperationException(path + " was not present in the CryPkg");
             FileInfo file = this.files[path];
             int offset = file.DataOffset + this.payloadOffset;
             byte[] output = new byte[file.Length];
@@ -92,13 +93,14 @@ namespace Common
             return MysteryTextDecoder.DecodeArbitraryBytesAsAppropriatelyAsPossible(bytes);
         }
 
-        public string[] ListDirectory(string path, bool justFiles)
+        public string[] ListDirectory(string path, bool includeFiles, bool includeDirectories)
         {
-            if (!this.files.ContainsKey(path) || !this.files[path].IsDirectory) throw new InvalidOperationException();
+            if (path.StartsWith("./")) path = path.Substring(2);
+            if (!this.files.ContainsKey(path) || !this.files[path].IsDirectory) throw new InvalidOperationException(path + " was not present in the CryPkg");
             int trimLength = path == "." ? 0 : path.Length + 1;
 
             return this.files[path].Children
-                .Where(k => this.files[k].IsDirectory != justFiles)
+                .Where(k => this.files[k].IsDirectory ? includeDirectories : includeFiles)
                 .Select(s => s.Substring(trimLength))
                 .OrderBy(t => t)
                 .ToArray();

--- a/Compiler/Common/PkgAwareFileUtil.cs
+++ b/Compiler/Common/PkgAwareFileUtil.cs
@@ -63,27 +63,28 @@ namespace Common
 
         public string[] ListFiles(string path)
         {
-            return this.ListDirectoryContents(path, true);
+            return this.ListDirectoryContents(path, true, false);
         }
 
         public string[] ListDirectories(string path)
         {
-            return this.ListDirectoryContents(path, false);
+            return this.ListDirectoryContents(path, false, true);
         }
 
-        private string[] ListDirectoryContents(string path, bool justFiles)
+        private static string[] emptyStringArray = new string[0];
+        private string[] ListDirectoryContents(string path, bool includeFiles, bool includeDirectories)
         {
             string fullPath = System.IO.Path.GetFullPath(path);
             if (System.IO.Directory.Exists(fullPath))
             {
-                return justFiles
-                    ? System.IO.Directory.GetFiles(fullPath)
-                    : System.IO.Directory.GetDirectories(fullPath);
+                IEnumerable<string> files = includeFiles ? System.IO.Directory.GetFiles(fullPath) : emptyStringArray;
+                IEnumerable<string> dirs = includeDirectories ? System.IO.Directory.GetDirectories(fullPath) : emptyStringArray;
+                return dirs.Concat(files).ToArray();
             }
 
             CryPkgPath pkgPath = GetPackagedPath(fullPath, true);
             if (pkgPath == null) throw new System.IO.DirectoryNotFoundException(path);
-            return pkgPath.Package.ListDirectory(pkgPath.Path, justFiles);
+            return pkgPath.Package.ListDirectory(pkgPath.Path, includeFiles, includeDirectories);
         }
 
         private CryPkgPath GetPackagedPath(string fullPath, bool isDir)

--- a/Compiler/Platform/TemplateSet.cs
+++ b/Compiler/Platform/TemplateSet.cs
@@ -14,7 +14,12 @@ namespace Platform
 
         public string GetText(string path)
         {
-            return Common.MysteryTextDecoder.DecodeArbitraryBytesAsAppropriatelyAsPossible(this.data[path]);
+            byte[] byteData;
+            if (!this.data.TryGetValue(path, out byteData))
+            {
+                throw new System.InvalidOperationException(path + " was not available in the template set. Files: " + string.Join(", ", this.data.Keys));
+            }
+            return Common.MysteryTextDecoder.DecodeArbitraryBytesAsAppropriatelyAsPossible(byteData);
         }
 
         public byte[] GetBytes(string path)


### PR DESCRIPTION
…t VM bundles rather than vmsrc/ files, which were missing and still had Pastel source.

This caused it to only work on people's computers who had the source present.